### PR TITLE
fix: surface real API error messages and cache auth tokens

### DIFF
--- a/lib/njtransit/client.rb
+++ b/lib/njtransit/client.rb
@@ -77,15 +77,26 @@ module NJTransit
     end
 
     def authenticate!
+      cached = self.class.token_cache[base_url]
+      if cached
+        @token = cached
+        return @token
+      end
+
       response = form_connection.post(auth_path) do |req|
         req.body = { username: username, password: password }
       end
 
       result = parse_body(response.body)
 
-      raise AuthenticationError, "Authentication failed" unless result.is_a?(Hash) && result["Authenticated"] == "True"
+      unless result.is_a?(Hash) && result["Authenticated"] == "True"
+        message = result.is_a?(Hash) && result["errorMessage"] ? result["errorMessage"] : "Authentication failed"
+        raise AuthenticationError, message
+      end
 
       @token = result["UserToken"]
+      self.class.token_cache[base_url] = @token
+      @token
     end
 
     def token
@@ -95,6 +106,15 @@ module NJTransit
 
     def clear_token!
       @token = nil
+      self.class.token_cache.delete(base_url)
+    end
+
+    def self.token_cache
+      @token_cache ||= {}
+    end
+
+    def self.clear_token_cache!
+      @token_cache = {}
     end
 
     private

--- a/spec/njtransit/client_spec.rb
+++ b/spec/njtransit/client_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe NJTransit::Client do
   let(:client) { described_class.new(username: "test_user", password: "test_pass") }
 
+  before { described_class.clear_token_cache! }
+
   describe "#initialize" do
     it "sets username" do
       expect(client.username).to eq("test_user")
@@ -94,6 +96,38 @@ RSpec.describe NJTransit::Client do
         expect { client.authenticate! }.to raise_error(NJTransit::AuthenticationError, "Authentication failed")
       end
     end
+
+    context "when rate limited" do
+      before do
+        body = '{"errorMessage":"Daily usage limit:10. Your current daily usage: 11"}'
+        response = instance_double(Faraday::Response, success?: true, body: body)
+        allow(connection).to receive(:post).and_yield(double(body: nil).as_null_object).and_return(response)
+      end
+
+      it "raises AuthenticationError with the API error message" do
+        expect { client.authenticate! }.to raise_error(
+          NJTransit::AuthenticationError,
+          "Daily usage limit:10. Your current daily usage: 11"
+        )
+      end
+    end
+
+    context "when token is cached" do
+      before do
+        allow(connection).to receive(:post).and_yield(double(body: nil).as_null_object).and_return(success_response)
+        client.authenticate!
+      end
+
+      it "reuses cached token for new client with same base_url" do
+        new_client = described_class.new(username: "test_user", password: "test_pass")
+        allow(new_client).to receive(:form_connection).and_return(connection)
+
+        new_client.authenticate!
+
+        expect(connection).to have_received(:post).once
+        expect(new_client.token).to eq("abc123")
+      end
+    end
   end
 
   describe "#token" do
@@ -109,6 +143,12 @@ RSpec.describe NJTransit::Client do
       client.instance_variable_set(:@token, "existing_token")
       client.clear_token!
       expect(client.instance_variable_get(:@token)).to be_nil
+    end
+
+    it "clears the token cache for that base_url" do
+      described_class.token_cache[client.base_url] = "cached_token"
+      client.clear_token!
+      expect(described_class.token_cache[client.base_url]).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary

- Auth errors like "Daily usage limit:10" were hidden behind generic "Authentication failed" — now the actual API `errorMessage` is surfaced
- Tokens are cached at the class level keyed by `base_url`, so `NJTransit.reset!` and new client instances reuse existing tokens instead of burning auth calls
- `clear_token!` also clears the cache for that base_url; `Client.clear_token_cache!` wipes all cached tokens

Closes #15

*Co-authored by Claude*