### PR TITLE
Add release workflow, CI tooling, and 1.0.0 release prep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "lib/njtransit/version.rb"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(ruby -r ./lib/njtransit/version -e 'puts NJTransit::VERSION')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build gem
+        run: gem build njtransit.gemspec
+
+      - name: Publish to RubyGems
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
+          mkdir -p ~/.gem
+          echo "---" > ~/.gem/credentials
+          echo ":rubygems_api_key: $RUBYGEMS_API_KEY" >> ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          gem push njtransit-${{ steps.version.outputs.version }}.gem
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          GEM_FILE: njtransit-${{ steps.version.outputs.version }}.gem
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            "$GEM_FILE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 ## [Unreleased]
+
+## [1.0.0] - 2026-03-27
+
+### Added
+
+- **Rail API** — train schedules, station messages, train stop lists, and live vehicle positions via `NJTransit.rail_client`
+- **Bus GTFS-RT** — real-time alerts, trip updates, and vehicle positions (`client.bus_gtfs`)
+- **Bus GTFS-RT G2** — newer version of bus feeds (`client.bus_gtfs_g2`)
+- **Rail GTFS-RT** — real-time rail feeds (`rail_client.rail_gtfs`)
+- **Light rail support** — `mode` parameter on bus API methods (`HBLR`, `NLR`, `RL`, `ALL`)
+- **GTFS static data** — full offline schedules via SQLite, with import/query/rake tasks
+- **Automatic enrichment** — bus API responses enriched with GTFS lat/lon and route names
+- **Token caching** — auth tokens cached across client instances to avoid hitting daily API limits
+- **Descriptive auth errors** — actual API error messages surfaced instead of generic "Authentication failed"
+- **CI pipeline** — RuboCop linting and RSpec on Ruby 3.2/3.3
+- **Automated releases** — publish to RubyGems on merge to main when version changes
+
+### Bus API
+
+- `routes`, `directions`, `stops`, `stop_name`, `departures`
+- `route_trips`, `trip_stops`, `stops_nearby`, `vehicles_nearby`
+- `locations` with mode filtering
+
+### Rail API
+
+- `stations`, `station_messages`, `station_schedule`
+- `train_schedule`, `train_schedule_19`, `train_stop_list`
+- `vehicle_data`
 
 ## [0.1.0] - 2026-01-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,107 +44,109 @@ bundle exec rspec spec/file.rb # Run a specific spec file
 
 All API calls are stubbed — no credentials needed for tests.
 
-## Development Workflow
+## Git Workflow
 
-### Complete Issue-to-Deploy Workflow
+Every change follows this process: Issue -> Branch -> Implement -> Commit -> PR -> CI -> Merge -> Release -> Cleanup.
 
-**Every change follows this workflow, even small/transient fixes:**
+### 1. Create Issue
 
+- Create a GitHub issue describing the work
+- Add the `claude` label to issues created by Claude
+- For human-created issues: add `claude:reviewed` label after reviewing (not both labels on same issue)
+- Include a **Success Criteria** section with testable checkbox items:
+  ```markdown
+  ## Success Criteria
+  - [ ] Feature X works as described
+  - [ ] All existing tests pass
+  - [ ] New tests added for feature X
+  ```
+- Note `*Co-authored by Claude*` if applicable
+
+### 2. Create Branch
+
+Branch naming convention:
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  1. CREATE ISSUE (if not exists)                                            │
-│     - Add `claude` label                                                    │
-│     - Include Success Criteria checkboxes                                   │
-│     - Note: "*Co-authored by Claude*"                                       │
-├─────────────────────────────────────────────────────────────────────────────┤
-│  2. CREATE BRANCH                                                           │
-│     - Format: fix/<issue-number>-<brief-description>                        │
-│     - Checkout the new branch                                               │
-├─────────────────────────────────────────────────────────────────────────────┤
-│  3. IMPLEMENT                                                               │
-│     - Write code, tests                                                     │
-│     - Update issue checkboxes as criteria are met                           │
-├─────────────────────────────────────────────────────────────────────────────┤
-│  4. COMMIT                                                                  │
-│     - Include "Closes #<issue-number>" in commit body                       │
-│     - Include "Co-Authored-By: Claude <noreply@anthropic.com>"              │
-├─────────────────────────────────────────────────────────────────────────────┤
-│  5. PUSH BRANCH                                                             │
-│     - Push to origin                                                        │
-├─────────────────────────────────────────────────────────────────────────────┤
-│  6. CREATE PR                                                               │
-│     - Use GitHub MCP (mcp__github__create_pull_request)                     │
-│     - Include "*Co-authored by Claude*" in body                             │
-│     - Always use merge commits (not squash)                                 │
-├─────────────────────────────────────────────────────────────────────────────┤
-│  7. WAIT FOR MERGE                                                          │
-│     - User reviews and merges, OR                                           │
-│     - User gives green light for Claude to merge via GitHub MCP             │
-├─────────────────────────────────────────────────────────────────────────────┤
-│  8. CLEANUP (after user confirms deployment is healthy or N/A)              │
-│     - git checkout main                                                     │
-│     - git pull origin main                                                  │
-│     - git branch -d <branch-name>                                           │
-│     - Delete remote branch via GitHub MCP or git push origin --delete       │
-│     - git fetch --prune                                                     │
-│                                                                             │
-│     ⚠️  DO NOT delete branch if deployment failed - may need to push fixes  │
-└─────────────────────────────────────────────────────────────────────────────┘
+fix/<issue-number>-<brief-description>
 ```
-
-**Note:** This repo does not have DigitalOcean deployment monitoring. After PR is merged, ask user for green light before branch cleanup.
-
-### GitHub Issue Requirements
-
-**Creating Issues (Claude):**
-- Always add the `claude` label
-- Note co-authorship in the issue body: `*Co-authored by Claude*`
-- Include a **Success Criteria** section with checkbox items
-
-**Reviewing Issues (Human-created):**
-- Issues without `claude` or `claude:reviewed` labels are human-created
-- After reading, add the `claude:reviewed` label
-- Never add both `claude` and `claude:reviewed` to the same issue
-
-### Success Criteria
-
-**Every issue should have a Success Criteria section** with testable checkbox items:
-
-```markdown
-## Success Criteria
-
-- [ ] Feature X works as described
-- [ ] All existing tests pass
-- [ ] New tests added for feature X
-```
-
-### Branch Naming Convention
-
-Format: `fix/<issue-number>-<brief-description>`
 
 Examples:
 - `fix/15-add-schedule-parsing`
 - `fix/23-fix-departure-times`
 
-### Commit Requirements
+### 3. Implement
 
-**Auto-close issues:** Include `Closes #<issue-number>` in the commit message body.
+- Write code and tests
+- Update issue checkboxes as criteria are met
+- Bump version in `lib/njtransit/version.rb`
+- Add entry to `CHANGELOG.md` under `[Unreleased]`
 
-**Co-authorship:** All commits must include:
+**Every PR must include** a version bump and changelog entry. Dependabot PRs are exempt.
+
+Follow [Semantic Versioning](https://semver.org/):
+- **PATCH** (0.0.x): Bug fixes, minor doc updates
+- **MINOR** (0.x.0): New features, new API methods
+- **MAJOR** (x.0.0): Breaking changes to public API
+
+### 4. Commit
+
+Every commit must include:
+- `Closes #<issue-number>` in the commit message body
+- Co-authorship footer:
+  ```
+  Co-Authored-By: Claude <noreply@anthropic.com>
+  ```
+
+Example:
 ```
+Add user authentication with Devise
+
+Closes #12
+
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
-### Pull Request Requirements
+### 5. Push & Create PR
 
-- Use GitHub MCP (`mcp__github__create_pull_request`) to create PRs
-- Use GitHub MCP (`mcp__github__merge_pull_request`) to merge when given green light
-- Include co-authorship note in PR body: `*Co-authored by Claude*`
-- **Always use merge commits** (squash merge is disabled)
+- Push branch to origin
+- Create PR using `gh pr create`
+- Include `*Co-authored by Claude*` in PR body
+- Always use **merge commits** (not squash)
 
-### Branch Cleanup
+### 6. Monitor CI
 
-**Only perform after user confirms deployment is healthy (or N/A):**
+```bash
+bin/ci-watch <pr-number>              # Check once
+bin/ci-watch <pr-number> --poll       # Poll every 10s until done
+bin/ci-watch <pr-number> --poll 30    # Poll every 30s
+```
+
+Exit codes: `0` = all passed, `1` = failed, `2` = still in progress.
+
+- **Exit 0**: notify user and await instruction to merge
+- **Exit 1**: investigate the failure, propose a fix — do NOT merge
+- **Exit 2**: check again later
+
+Do NOT merge the PR automatically. Wait for explicit user instruction.
+
+### 7. Merge PR
+
+After CI passes and user gives explicit instruction:
+
+```bash
+gh pr merge <pr-number> --merge
+```
+
+### 8. Monitor Release
+
+If version was bumped, a release workflow runs automatically on merge to main:
+1. Runs the test suite
+2. Builds the gem
+3. Publishes to RubyGems
+4. Creates a GitHub release with the gem attached
+
+Monitor with: `gh run watch` (select the Release workflow). Confirm gem was published to rubygems.org.
+
+### 9. Cleanup (only after release is healthy)
 
 ```bash
 git checkout main
@@ -153,3 +155,5 @@ git branch -d <branch-name>
 git push origin --delete <branch-name>
 git fetch --prune
 ```
+
+Do NOT delete the branch if the release failed — it may be needed for fixes.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    njtransit (0.1.0)
+    njtransit (1.0.0)
       faraday (~> 2.0)
       faraday-multipart (~> 1.0)
       faraday-typhoeus (>= 1, < 3)

--- a/bin/ci-watch
+++ b/bin/ci-watch
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks GitHub Actions CI status for a PR.
+# Usage: bin/ci-watch <pr-number> [--poll [interval]]
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+#   2 — checks still in progress (single-check mode only)
+
+if [ $# -lt 1 ]; then
+  echo "Usage: bin/ci-watch <pr-number> [--poll [interval]]" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+shift
+
+POLL=false
+INTERVAL=10
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --poll)
+      POLL=true
+      if [ $# -ge 2 ] && [[ "$2" =~ ^[0-9]+$ ]]; then
+        INTERVAL="$2"
+        shift
+      fi
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+check_once() {
+  OUTPUT=$(gh pr checks "$PR_NUMBER" 2>&1) && {
+    echo "$OUTPUT"
+    echo ""
+    echo "All checks passed."
+    return 0
+  }
+
+  if echo "$OUTPUT" | grep -qE '\bpending\b|\bin_progress\b'; then
+    echo "$OUTPUT"
+    echo ""
+    echo "Checks still running."
+    return 2
+  else
+    echo "$OUTPUT"
+    echo ""
+    echo "CI failed."
+    return 1
+  fi
+}
+
+if [ "$POLL" = true ]; then
+  echo "Watching CI checks for PR #${PR_NUMBER} (polling every ${INTERVAL}s)..."
+  while true; do
+    rc=0
+    check_once || rc=$?
+    if [ "$rc" -eq 2 ]; then
+      echo "Polling again in ${INTERVAL}s..."
+      echo "---"
+      sleep "$INTERVAL"
+    else
+      exit "$rc"
+    fi
+  done
+else
+  rc=0
+  check_once || rc=$?
+  exit "$rc"
+fi

--- a/lib/njtransit/version.rb
+++ b/lib/njtransit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NJTransit
-  VERSION = "0.1.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` for automated RubyGems publishing on version bump
- Add `bin/ci-watch` for polling GitHub Actions CI status
- Restructure CLAUDE.md Git Workflow into clean numbered steps
- Bump version `0.1.0` → `1.0.0`
- Add full 1.0.0 changelog

Closes #17

*Co-authored by Claude*