### PR TITLE
Add bin/release-watch and update docs for CI/release tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-03-27
+
+### Added
+
+- `bin/release-watch` — monitors release workflow and confirms gem is live on RubyGems
+
+### Changed
+
+- Updated CLAUDE.md step 8 to use `bin/release-watch`
+- Updated README.md with CI and release tooling documentation
+
 ## [1.0.1] - 2026-03-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,20 @@ gh pr merge <pr-number> --merge
 If version was bumped, a release workflow runs automatically on merge to main:
 1. Runs the test suite
 2. Builds the gem
-3. Publishes to RubyGems
+3. Publishes to RubyGems (via Trusted Publishing / OIDC)
 4. Creates a GitHub release with the gem attached
 
-Monitor with: `gh run watch` (select the Release workflow). Confirm gem was published to rubygems.org.
+```bash
+bin/release-watch                # Check once
+bin/release-watch --poll         # Poll every 15s until done
+bin/release-watch --poll 30      # Poll every 30s
+```
+
+Exit codes: `0` = gem published, `1` = workflow failed, `2` = still in progress.
+
+- **Exit 0**: gem is live on RubyGems — proceed to cleanup
+- **Exit 1**: investigate failure, propose fix — do NOT delete branch
+- **Exit 2**: check again later
 
 ### 9. Cleanup (only after release is healthy)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    njtransit (1.0.1)
+    njtransit (1.0.2)
       faraday (~> 2.0)
       faraday-multipart (~> 1.0)
       faraday-typhoeus (>= 1, < 3)

--- a/README.md
+++ b/README.md
@@ -135,8 +135,19 @@ Claude writes and runs Ruby code against the gem to answer your question. It's a
 
 ```sh
 bin/setup          # Install dependencies
-bundle exec rspec  # Run tests (153 specs)
+bundle exec rspec  # Run tests
 bin/console        # Interactive prompt
+```
+
+### CI & Release
+
+CI runs automatically on pull requests (RuboCop + RSpec on Ruby 3.2/3.3). Merging to main with a version bump triggers the release workflow, which publishes to RubyGems via Trusted Publishing and creates a GitHub release.
+
+```sh
+bin/ci-watch <pr-number>         # Check CI status for a PR
+bin/ci-watch <pr-number> --poll  # Poll until CI completes
+bin/release-watch                # Check release workflow status
+bin/release-watch --poll         # Poll until gem is published
 ```
 
 ## Contributing

--- a/bin/release-watch
+++ b/bin/release-watch
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Monitors the GitHub Actions release workflow and confirms the gem is live on RubyGems.
+# Usage: bin/release-watch [--poll [interval]]
+#
+# Exit codes:
+#   0 — gem published and GitHub release created
+#   1 — release workflow failed
+#   2 — release still in progress (single-check mode only)
+
+POLL=false
+INTERVAL=15
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --poll)
+      POLL=true
+      if [ $# -ge 2 ] && [[ "$2" =~ ^[0-9]+$ ]]; then
+        INTERVAL="$2"
+        shift
+      fi
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Find the most recent release workflow run
+RUN_ID=$(gh run list --workflow=release.yml --limit=1 --json databaseId --jq '.[0].databaseId' 2>&1)
+
+if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+  echo "No release workflow runs found."
+  exit 1
+fi
+
+# Get expected version from version.rb
+EXPECTED_VERSION=$(ruby -r ./lib/njtransit/version -e 'puts NJTransit::VERSION')
+
+echo "Watching release workflow (run $RUN_ID) for njtransit v${EXPECTED_VERSION}..."
+
+check_once() {
+  STATUS=$(gh run view "$RUN_ID" --json status,conclusion --jq '"\(.status) \(.conclusion)"' 2>&1)
+  RUN_STATUS=$(echo "$STATUS" | awk '{print $1}')
+  CONCLUSION=$(echo "$STATUS" | awk '{print $2}')
+
+  case "$RUN_STATUS" in
+    completed)
+      if [ "$CONCLUSION" = "success" ]; then
+        echo "Release workflow passed."
+        echo ""
+
+        # Confirm gem is live on RubyGems
+        LIVE_VERSION=$(gem search njtransit --remote 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+        if [ "$LIVE_VERSION" = "$EXPECTED_VERSION" ]; then
+          echo "njtransit $LIVE_VERSION is live on RubyGems."
+          return 0
+        else
+          echo "WARNING: Workflow succeeded but RubyGems shows v${LIVE_VERSION:-none}, expected v${EXPECTED_VERSION}."
+          echo "It may take a moment for RubyGems to update. Try again shortly."
+          return 2
+        fi
+      else
+        echo "Release workflow failed (conclusion: $CONCLUSION)."
+        echo ""
+        echo "View logs: gh run view $RUN_ID --log-failed"
+        return 1
+      fi
+      ;;
+    *)
+      echo "Release workflow still running (status: $RUN_STATUS)."
+      return 2
+      ;;
+  esac
+}
+
+if [ "$POLL" = true ]; then
+  while true; do
+    rc=0
+    check_once || rc=$?
+    if [ "$rc" -eq 2 ]; then
+      echo "Polling again in ${INTERVAL}s..."
+      echo "---"
+      sleep "$INTERVAL"
+    else
+      exit "$rc"
+    fi
+  done
+else
+  rc=0
+  check_once || rc=$?
+  exit "$rc"
+fi

--- a/lib/njtransit/version.rb
+++ b/lib/njtransit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NJTransit
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
## Summary

- Add `bin/release-watch` — monitors GitHub Actions release workflow and confirms gem is live on RubyGems (same interface as `bin/ci-watch`: single check or `--poll`, exit codes 0/1/2)
- Update CLAUDE.md step 8 to use `bin/release-watch` with full exit code docs
- Update README.md Development section with CI and release tooling

Closes #21

*Co-authored by Claude*