### PR TITLE
Stub ENV in configuration initialize specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-04-26
+
+### Fixed
+
+- `Configuration` initialize specs now stub `NJTRANSIT_USERNAME` / `NJTRANSIT_PASSWORD` so they pass regardless of the host environment
+
 ## [1.1.0] - 2026-03-27
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    njtransit (1.1.0)
+    njtransit (1.1.1)
       faraday (~> 2.0)
       faraday-multipart (~> 1.0)
       faraday-typhoeus (>= 1, < 3)

--- a/lib/njtransit/version.rb
+++ b/lib/njtransit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NJTransit
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/spec/njtransit/configuration_spec.rb
+++ b/spec/njtransit/configuration_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe NJTransit::Configuration do
   let(:config) { described_class.new }
 
   describe "#initialize" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("NJTRANSIT_USERNAME", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("NJTRANSIT_PASSWORD", nil).and_return(nil)
+    end
+
     it "sets default base_url" do
       expect(config.base_url).to eq("https://pcsdata.njtransit.com")
     end


### PR DESCRIPTION
## Summary
- `Configuration#initialize` reads `username` and `password` from `ENV.fetch("NJTRANSIT_USERNAME"|"NJTRANSIT_PASSWORD", nil)`, but the defaults-to-nil specs didn't stub ENV — so any developer with those vars set in their shell saw two failures locally (and a blocked pre-push hook), even though CI was green.
- Stub `ENV.fetch` for those two keys at the `#initialize` describe scope.
- Bumps version to 1.1.1 and adds CHANGELOG entry.

Closes #34

## Test plan
- [ ] `bundle exec rspec spec/njtransit/configuration_spec.rb` passes locally with NJTRANSIT_USERNAME/PASSWORD set
- [ ] `bundle exec rspec spec/njtransit/configuration_spec.rb` passes locally with them unset
- [ ] CI green on Ruby 3.2 and 3.3

*Co-authored by Claude*