### PR TITLE
Add Ruby 3.4 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.2", "3.3"]
+        ruby-version: ["3.2", "3.3", "3.4"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 - CI test matrix now includes Ruby 3.4 alongside 3.2 and 3.3
 
+### Fixed
+
+- Declare `csv` as a runtime dependency (no longer a default gem in Ruby 3.4)
+
 ## [1.1.1] - 2026-04-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-04-26
+
+### Changed
+
+- CI test matrix now includes Ruby 3.4 alongside 3.2 and 3.3
+
 ## [1.1.1] - 2026-04-26
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     njtransit (1.1.2)
+      csv (~> 3.0)
       faraday (~> 2.0)
       faraday-multipart (~> 1.0)
       faraday-typhoeus (>= 1, < 3)
@@ -14,6 +15,7 @@ GEM
   specs:
     ast (2.4.3)
     bigdecimal (4.1.0)
+    csv (3.3.5)
     diff-lcs (1.6.2)
     dotenv (3.2.0)
     ethon (0.18.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    njtransit (1.1.1)
+    njtransit (1.1.2)
       faraday (~> 2.0)
       faraday-multipart (~> 1.0)
       faraday-typhoeus (>= 1, < 3)

--- a/lib/njtransit/version.rb
+++ b/lib/njtransit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NJTransit
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/njtransit.gemspec
+++ b/njtransit.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Dependencies
+  spec.add_dependency "csv", "~> 3.0"
   spec.add_dependency "faraday", "~> 2.0"
   spec.add_dependency "faraday-multipart", "~> 1.0"
   spec.add_dependency "faraday-typhoeus", ">= 1", "< 3"


### PR DESCRIPTION
## Summary
- Adds `"3.4"` to the test matrix in `.github/workflows/ci.yml` alongside 3.2 and 3.3.
- Bumps version to 1.1.2 and adds CHANGELOG entry.

Closes #31

## Test plan
- [ ] CI passes on Ruby 3.2
- [ ] CI passes on Ruby 3.3
- [ ] CI passes on Ruby 3.4

*Co-authored by Claude*