### PR TITLE
Add Documentation Sync table to CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-04-26
+
+### Added
+
+- `CLAUDE.md` "Documentation Sync" section with a table mapping change types to required doc surfaces
+
 ## [1.1.2] - 2026-04-26
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,28 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Documentation Sync
+
+Any change that affects public behavior, configuration, dependencies, or the release process **must** update every relevant doc surface **in the same PR**. Docs that go stale silently are worse than docs that are missing — readers learn not to trust them.
+
+### Which doc owns which kind of change
+
+| Change | Update |
+|---|---|
+| New or changed public API (method signature, return shape, error class raised) | `README.md` (capability section + relevant examples), `CHANGELOG.md` |
+| New resource class or API host | `CLAUDE.md` Architecture section, `README.md` "Two Clients" table, `CHANGELOG.md` |
+| New environment variable | `README.md` "Environment Variables" table, `CHANGELOG.md` if user-visible |
+| GTFS schema or data-layer changes | `CLAUDE.md` "GTFS Static Layer" section, `README.md` "GTFS Static Data" section if it surfaces in usage |
+| New rake task | `README.md` (where rake tasks are listed), `CHANGELOG.md` |
+| RubyGems metadata change (runtime deps, license, URLs, summary) | `njtransit.gemspec`, `CHANGELOG.md` |
+| New `bin/` script | `README.md` "Development" or "CI & Release" section, `CHANGELOG.md` |
+| CI workflow change | `.github/workflows/ci.yml`, `README.md` "CI & Release" section if it changes the user-facing flow |
+| Release workflow change | `.github/workflows/release.yml`, `README.md` "CI & Release" section if it changes the user-facing flow, `CLAUDE.md` Git Workflow section if the process changes |
+| Git workflow change (issue/branch/commit conventions) | `CLAUDE.md` Git Workflow section |
+| `install-skill` / CLI behavior change | `README.md` "Using with Claude Code" section, `CHANGELOG.md` |
+
+If a change clearly touches multiple categories, all of them apply. If it touches none of them (refactors, internal cleanup with no behavior change), no docs change is required — but call that out in the PR description so it's intentional, not an oversight.
+
 ## Architecture
 
 ### Two Clients

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    njtransit (1.1.2)
+    njtransit (1.1.3)
       csv (~> 3.0)
       faraday (~> 2.0)
       faraday-multipart (~> 1.0)

--- a/lib/njtransit/version.rb
+++ b/lib/njtransit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NJTransit
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end


### PR DESCRIPTION
## Summary
- Adds a "Documentation Sync" section to `CLAUDE.md` with a table mapping change types (public API, new resource class, new env var, GTFS changes, new rake task, gemspec changes, new bin/ script, CI/release workflow changes, git workflow changes, install-skill changes) to the doc surfaces they must update in the same PR.
- Mirrors the pattern from the sibling `pure_greeks` gem.
- Bumps version to 1.1.3 and adds CHANGELOG entry.

Closes #32

## Test plan
- [ ] CI green (lint + 3.2/3.3/3.4 tests)
- [ ] Table renders correctly on GitHub

*Co-authored by Claude*