### PR TITLE
Run rubocop in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Run tests
         run: bundle exec rspec
 
+      - name: Run linter
+        run: bundle exec rubocop --parallel -f github
+
       - name: Extract version
         id: version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-04-26
+
+### Changed
+
+- Release workflow now runs RuboCop in addition to RSpec before publishing the gem
+
 ## [1.1.3] - 2026-04-26
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    njtransit (1.1.3)
+    njtransit (1.1.4)
       csv (~> 3.0)
       faraday (~> 2.0)
       faraday-multipart (~> 1.0)

--- a/lib/njtransit/version.rb
+++ b/lib/njtransit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NJTransit
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end


### PR DESCRIPTION
## Summary
- Adds a `Run linter` step (`bundle exec rubocop --parallel -f github`) to `release.yml` after RSpec and before building the gem.
- Belt-and-suspenders against a lint regression sneaking through if a PR were force-merged or otherwise bypassed CI; mirrors the sibling `pure_greeks` release workflow.
- Bumps version to 1.1.4 and adds CHANGELOG entry.

Closes #33

## Test plan
- [ ] CI green (lint + 3.2/3.3/3.4 tests)
- [ ] Release workflow succeeds end-to-end on merge (1.1.4 reaches RubyGems)

*Co-authored by Claude*